### PR TITLE
FlipSign Quantum Gate

### DIFF
--- a/QuantumFramework/Kernel/ExampleRepository.m
+++ b/QuantumFramework/Kernel/ExampleRepository.m
@@ -16,6 +16,10 @@ PackageExport["FubiniStudyMetricTensor"]
 
 PackageExport["FubiniStudyMetricTensorLayers"]
 
+PackageExport["FlipSign"]
+
+PackageExport["CFlipSign"]
+
 
 
 (* ::Section::Closed:: *)
@@ -273,3 +277,43 @@ centralFiniteDifference[f_[vars__],var_,val_]:=With[{h=10.^-3},
 			1/(2 h) ((f[vars]/.var->val+h)-(f[vars]/.var->val-h))
 			
 		]
+
+
+(* ::Section:: *)
+(*QuantumGates*)
+
+
+BinaryStringQ[s_String]:=StringMatchQ[s,StringExpression[("0"|"1")..]];
+
+FlipSign[state_String ? BinaryStringQ]:=Module[{positions},
+	positions={
+		{StringLength[#]},
+		(StringPosition[StringDrop[#,-1],"0"][[All,1]]),
+		(StringPosition[StringDrop[#,-1],"1"][[All,1]])
+		}&@state;
+
+	If[
+		StringMatchQ[state,__~~"1"],
+			QuantumCircuitOperator[{{"C","Z",positions[[1]],positions[[3]],positions[[2]]}},"Label"->"FlipSign"],
+			QuantumCircuitOperator[{"X"->positions[[1]],{"C","Z",positions[[1]],positions[[3]],positions[[2]]},"X"->positions[[1]]},"Label"->"FlipSign"]
+	]
+]
+
+
+CFlipSign[state_String ? BinaryStringQ]:=Module[{result,positions},
+
+	positions={
+		{StringLength[#]+1},
+		(StringPosition[StringDrop[#,-1],"0"][[All,1]]+1),
+		(StringPosition[StringDrop[#,-1],"1"][[All,1]]+1)
+		}&@state;
+
+	result=If[
+		StringMatchQ[state,__~~"1"],
+			QuantumOperator[{"C",{"C","Z",positions[[1]],positions[[3]],positions[[2]]},{1}}],
+			QuantumCircuitOperator[{"C",{"X"->positions[[1]],{"C","Z",positions[[1]],positions[[3]],positions[[2]]},"X"->positions[[1]]},{1}}]
+	];
+	
+	QuantumCircuitOperator[result,"Label"->"\!\(\*SubscriptBox[\(C\), \(FlipSign\)]\)"]
+	
+]

--- a/QuantumFramework/Kernel/ExampleRepository.m
+++ b/QuantumFramework/Kernel/ExampleRepository.m
@@ -310,7 +310,7 @@ CFlipSign[state_String ? BinaryStringQ]:=Module[{result,positions},
 
 	result=If[
 		StringMatchQ[state,__~~"1"],
-			QuantumOperator[{"C",{"C","Z",positions[[1]],positions[[3]],positions[[2]]},{1}}],
+			QuantumCircuitOperator[{"C",{"C","Z",positions[[1]],positions[[3]],positions[[2]]},{1}}],
 			QuantumCircuitOperator[{"C",{"X"->positions[[1]],{"C","Z",positions[[1]],positions[[3]],positions[[2]]},"X"->positions[[1]]},{1}}]
 	];
 	


### PR DESCRIPTION
Added a FlipSign gate to Repository Example functions and a Controlled version.

As the name explains, flips the sign of a given basis state. In other words, it acts as the following:

![image](https://github.com/sw1sh/QuantumFramework/assets/72677149/5346cd3a-a556-4e32-81cd-368d519b2234)


where the input is m and the basis state is n .

This implementation follow the qml.FlipSign gate from PennyLane: https://docs.pennylane.ai/en/stable/code/api/pennylane.FlipSign.html

The gate input is a binary string conformed only by "0" or "1".  This string represent a state |input> so the gate depends entirely in the state of each qubit in order to know if the controlled gate acts on |0>or |1>. Also the state of the last qubit determines if "PauliX" gates are required in the last qubit.

This gate will be required for a Quantum Lock Mechanism example.

Brief test:

```
FlipSign["1100"]["Diagram", ImageSize -> Small]
```

![image](https://github.com/sw1sh/QuantumFramework/assets/72677149/5097cff8-4d59-42e9-9250-a532687d2ff8)

```
QuantumCircuitOperator[{
   "H" -> {1},
   CFlipSign["0111"],
   "H" -> {1},
   QuantumMeasurementOperator["Computational", {1}]
   }]["Diagram"]
```
![image](https://github.com/sw1sh/QuantumFramework/assets/72677149/6a7ac711-e0a4-4f5b-8116-35a3d5154f8e)

