### PR TITLE
Fixed bug in entropy of entanglement calculation

### DIFF
--- a/QuantumFramework/Kernel/QuantumEntanglement.m
+++ b/QuantumFramework/Kernel/QuantumEntanglement.m
@@ -57,7 +57,7 @@ QuantumEntanglementMonotone[qs_ ? QuantumStateQ, biPartition_ : Automatic, "LogN
 QuantumEntanglementMonotone[qs_ ? QuantumStateQ, biPartition_ : Automatic, "EntanglementEntropy"] := Enclose @ With[{
     bp = ConfirmBy[qs["Bipartition", biPartition]["Normalized"], QuantumStateQ[#] && #["Qudits"] == 2 &]
 },
-    If[ qs["VectorQ"],
+    If[ bp["VectorQ"],
         Quantity[Total[-# Log2[#] & @ Select[Confirm @ bp["Probability"], # > 0 &]], "Bits"],
         QuantumPartialTrace[bp, {1}]["VonNeumannEntropy"]
     ]


### PR DESCRIPTION
When calculating the entropy of entanglement across a bipartition the code short-circuits the calculation using the known formula for pure state inputs. 

However, this formula is erroneously also used to calculate the entropy of entanglement for mixed states when the bipartition does not span the whole state, as the purity check is done on the state prior to bipartition. When the 'unused' modes are traced out by the bipartition function the output state may no longer be pure, even if the input state is, and so the full reduced density matrix approach may be needed in those cases.

Fixed by changing the purity check from being against qs (input state) to bp (bipartitioned state)